### PR TITLE
use an info.py file to allow integration with casa-distro/bv_maker

### DIFF
--- a/dico_toolbox/__init__.py
+++ b/dico_toolbox/__init__.py
@@ -21,4 +21,4 @@ except ImportError:
     _HAS_AIMS = False
     log.warn("Can not import pyAims, are you in a brainvisa environment?")
 
-__version__ = "0.1.0"
+from .info import __version__

--- a/dico_toolbox/info.py
+++ b/dico_toolbox/info.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+version_major = 0
+version_minor = 1
+version_micro = 0
+version_extra = ''
+
+# Format expected by setup.py and doc/source/conf.py: string of form "X.Y.Z"
+__version__ = "%s.%s.%s%s" % (version_major,
+                              version_minor,
+                              version_micro,
+                              version_extra)
+CLASSIFIERS = [
+    "Programming Language :: Python",
+    "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+    "Operating System :: OS Independent",
+]
+
+
+description = "A common toolbox to the FoldDico project"
+
+# versions for dependencies
+SPHINX_MIN_VERSION = '1.0'
+
+# Main setup parameters
+NAME = 'dico_toolbox'
+PROJECT = 'dico_toolbox'
+ORGANISATION = "neurospin"
+MAINTAINER = "nobody"
+MAINTAINER_EMAIL = "support@neurospin.info"
+DESCRIPTION = description
+URL = "https://github.com/neurospin/dico_toolbox"
+DOWNLOAD_URL = "https://github.com/neurospin/dico_toolbox"
+LICENSE = "CeCILL-B"
+AUTHOR = 'Marco Pascucci, Bastien Cagna'
+AUTHOR_EMAIL = 'marpas.paris@gmail.com'
+PLATFORMS = "OS Independent"
+PROVIDES = ["dico_toolbox"]
+REQUIRES = ['numpy']
+EXTRA_REQUIRES = {
+    "doc": ["sphinx>=" + SPHINX_MIN_VERSION],
+    'dev': ['pytest']
+}
+
+brainvisa_build_model = 'pure_python'
+

--- a/setup.py
+++ b/setup.py
@@ -6,17 +6,6 @@ import logging as _logging
 _log = _logging.getLogger(__name__)
 
 
-def get_property(prop, project):
-    lookup_file = '/__init__.py'
-    result = re.findall(r'^{}\s*=\s*[\'"]([^\'"]*)[\'"]$'.format(
-        prop), open(project + lookup_file).read(), re.MULTILINE)
-    # re.findall always returns list
-    if len(result) != 1:
-        _log.warn("Alert: More than one occurrence of {} found in {}}".format([prop, project + lookup_file]))
-    assert type(result[0]) == str
-    return result[0]
-
-
 try:
     from aims import soma
 except:
@@ -26,26 +15,24 @@ except:
 with open(op.join(op.split(__file__)[0], "README.md"), "r") as fh:
     long_description = fh.read()
 
+release_info = {}
+python_dir = os.path.dirname(__file__)
+with open(os.path.join(python_dir, "dico_toolbox", "info.py")) as f:
+    code = f.read()
+    exec(code, release_info)
+
 
 setuptools.setup(
-    name='dico_toolbox',
-    version=get_property('__version__', 'dico_toolbox'),
-    description="A common toolbox to the FoldDico project",
-    author='Marco Pascucci, Bastien Cagna',
+    name=release_info['NAME'],
+    version=release_info['__version__'],
+    description=release_info['DESCRIPTION'],
+    author=release_info['AUTHOR'],
+    author_email=release_info['AUTHOR_EMAIL']
     long_description=long_description,
     long_description_content_type="text/markdown",
-    author_email='marpas.paris@gmail.com',
-    url='',
+    url=release_info['URL'],
     packages=['dico_toolbox'],
-    install_requires=['numpy'],
-    extras_require={
-        'dev': [
-            'pytest'
-        ]
-    },
-    classifiers=[
-        "Programming Language :: Python",
-        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
-        "Operating System :: OS Independent",
-    ]
+    install_requires=release_info["REQUIRES"],
+    classifiers=release_info["CLASSIFIERS"]
+    extras_require=release_info['EXTRA_REQUIRES']
 )


### PR DESCRIPTION
this is just a separation of what was in setup.py into 2 files, the
info.py file being read by bv_maker not only for setup. Moreover it
allows to get info at runtime (to get library version etc) when needed.